### PR TITLE
Loosen typed interface for simple engines

### DIFF
--- a/react-native-game-engine.d.ts
+++ b/react-native-game-engine.d.ts
@@ -22,14 +22,14 @@ declare module "react-native-game-engine" {
     export function DefaultTouchProcessor (touchProcessorOptions?: TouchProcessorOptions): any;
   
     export interface GameEngineProperties {
-      systems: any[];
-      entities: {} | Promise<any>;
-      renderer: any;
-      touchProcessor: any;
-      timer: any;
-      running: boolean;
-      onEvent: any;
-      style: StyleProp<ViewStyle>;
+      systems?: any[];
+      entities?: {} | Promise<any>;
+      renderer?: any;
+      touchProcessor?: any;
+      timer?: any;
+      running?: boolean;
+      onEvent?: any;
+      style?: StyleProp<ViewStyle>;
       children: React.ReactNode;
     }
   


### PR DESCRIPTION
Currently the GameEngine interface is very strict and throws ts errors when a simple engine is defined:


```tsx
<GameEngine
  style={styles.container}
  systems={[MoveFinger]}
  entities={{
    1: { position: [40, 200], renderer: <Finger /> },
    2: { position: [100, 200], renderer: <Finger /> },
    3: { position: [160, 200], renderer: <Finger /> },
    4: { position: [220, 200], renderer: <Finger /> },
    5: { position: [280, 200], renderer: <Finger /> }
  }}
>
  <StatusBar hidden={true} />
</GameEngine>
```