### PR TITLE
Remove deprecation warnings for react 16.9.x

### DIFF
--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -53,13 +53,13 @@ export default class GameEngine extends Component {
     );
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     this.stop();
     this.timer.unsubscribe(this.updateHandler);
     if (this.touchProcessor.end) this.touchProcessor.end();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.running !== this.props.running) {
       if (nextProps.running) this.start();
       else this.stop();

--- a/src/GameLoop.js
+++ b/src/GameLoop.js
@@ -19,13 +19,13 @@ export default class GameLoop extends Component {
     if (this.props.running) this.start();
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     this.stop();
     this.timer.unsubscribe(this.updateHandler);
     if (this.touchProcessor.end) this.touchProcessor.end();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.running !== this.props.running) {
       if (nextProps.running) this.start();
       else this.stop();


### PR DESCRIPTION
## Included in this PR
- Fix lifecycle deprecation warnings for react 16.9.x (see [this](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount))
- Created #28 to clean this up later