### PR TITLE
replace old filenames for index.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ const MoveFinger = (entities, { touches }) => {
 export { MoveFinger };
 ```
 
-Finally let's bring it all together in our ```index.ios.js``` (or ```index.android.js```):
+Finally let's bring it all together in our ```index.js```:
 
 ```javascript
 import React, { PureComponent } from "react";


### PR DESCRIPTION
Most of RN users nowadays use a version which doesn't have two separate index files. Please consider updating the docs accordingly.