### PR TITLE
Fix long press handling

### DIFF
--- a/src/DefaultTouchProcessor.js
+++ b/src/DefaultTouchProcessor.js
@@ -8,12 +8,14 @@ import {
 	map,
 	groupBy,
 	filter,
-	pairwise
+	pairwise,
+	combineAll
 } from "rxjs/operators";
 
 export default ({
 	triggerPressEventBefore = 200,
-	triggerLongPressEventAfter = 700
+	triggerLongPressEventAfter = 700,
+	moveSensitivity = 0.5
 }) => {
 	return touches => {
 		let touchStart = new Subject().pipe(
@@ -34,20 +36,6 @@ export default ({
 				)
 			),
 			map(e => ({ ...e, type: "press" }))
-		);
-
-		let longTouch = touchStart.pipe(
-			mergeMap(e =>
-				of(e).pipe(
-					delay(triggerLongPressEventAfter),
-					takeUntil(
-						merge(touchMove, touchEnd).pipe(
-							first(x => x.id === e.id)
-						)
-					)
-				)
-			),
-			map(e => ({ ...e, type: "long-press" }))
 		);
 
 		let touchMoveDelta = merge(touchStart, touchMove, touchEnd).pipe(
@@ -76,12 +64,31 @@ export default ({
 			)
 		);
 
+		let realMove = touchMoveDelta.pipe(combineAll(),
+			filter(e => e.delta.pageX**2 + e.delta.pageY**2 > moveSensitivity**2)
+		);
+
+		let longTouch = touchStart.pipe(
+			mergeMap(e =>
+				of(e).pipe(
+					delay(triggerLongPressEventAfter),
+					takeUntil(
+						merge(realMove, touchEnd).pipe(
+							first(x => x.id === e.id)
+						)
+					)
+				)
+			),
+			map(e => ({ ...e, type: "long-press" }))
+		);
+
 		let subscriptions = [
 			touchStart,
 			touchEnd,
 			touchPress,
-			longTouch,
-			touchMoveDelta
+			touchMoveDelta,
+			realMove,
+			longTouch
 		].map(x => x.subscribe(y => touches.push(y)));
 
 		return {


### PR DESCRIPTION
Add move sensitivity parameter to touch processor to handle the case
real Android device is too sensitive, lead to long press events is
not detected when user press and hold