### PR TITLE
Added types to type declarations, increased specificity for systems and touch events

### DIFF
--- a/react-native-game-engine.d.ts
+++ b/react-native-game-engine.d.ts
@@ -21,7 +21,24 @@ declare module "react-native-game-engine" {
     }
   
     export function DefaultTouchProcessor (touchProcessorOptions?: TouchProcessorOptions): any;
+
+    export interface TimeUpdate {
+      current: number;
+      delta: number;
+      previous: number;
+      previousDelta: number;
+    }
+
+    export interface GameEngineUpdateEventOptionType {
+      dispatch: (event: any) => void;
+      events: Array<any>;
+      screen: ScaledSize;
+      time: TimeUpdate;
+      touches: Array<TouchEvent>;
+    }
   
+    export type GameEngineSystem = (entities: any, update: GameEngineUpdateEventOptionType) => any;
+
     export interface GameEngineProperties {
       systems?: any[];
       entities?: {} | Promise<any>;
@@ -35,23 +52,43 @@ declare module "react-native-game-engine" {
     }
   
     export class GameEngine extends React.Component<GameEngineProperties> {}
+
+    export type TouchEventType = 'start' | 'end' | 'move' | 'press' | 'long-press';
   
-    interface GameLoopUpdateEventOptionType {
-      touches: any[];
-      screen: ScaledSize;
-      time: {
-        current: number;
-        previous: number;
-        delta: number;
-        previousDelta: number;
+    export interface TouchEvent {
+      event: {
+        changedTouches: Array<TouchEvent>;
+        identifier: number;
+        locationX: number;
+        locationY: number;
+        pageX: number;
+        pageY: number;
+        target: number;
+        timestamp: number;
+        touches: Array<TouchEvent>;
       };
+      id: number;
+      type: TouchEventType;
+      delta?: {
+        locationX: number;
+        locationY: number;
+        pageX: number;
+        pageY: number;
+        timestamp: number;
+      }
+    }
+
+    interface GameLoopUpdateEventOptionType {
+      touches: TouchEvent[];
+      screen: ScaledSize;
+      time: TimeUpdate;
     }
   
     export interface GameLoopProperties {
       touchProcessor?: any;
       timer?: any;
       running?: boolean;
-      onUpdate?: (args?: GameLoopUpdateEventOptionType) => void;
+      onUpdate?: (args: GameLoopUpdateEventOptionType) => void;
       style?: StyleProp<ViewStyle>;
       children?: React.ReactNode;
     }


### PR DESCRIPTION
Replaced some of the `any` declarations in the TypeScript declaration file. This should make development better for those who opt to use TypeScript, as there is less ambiguity about what certain types are.

I kept entities and events any for flexibility, but I more rigidly defined system functions and touch events.

Note: line 54 (now line 91) was changed because `args` should not be optional in the signature. A bit counterintuitive, but the `?` makes it so that a function `const handleUpdate = (args: GameLoopUpdateEventOptionType) => { /* anything */ }` does not match the type because it expects args to be optional. This fix allows both `(args: GameLoopUpdateEventOptionType) => {}` and `() => {}` to be valid types.